### PR TITLE
Improving shape scale

### DIFF
--- a/app/assets/javascripts/backbone/apps/board/show/show_view.js
+++ b/app/assets/javascripts/backbone/apps/board/show/show_view.js
@@ -124,18 +124,17 @@ this.VelhaMania.module('BoardApp.Show', function (Show, App, Backbone, Marionett
         childView: Show.PositionView,
         childEvents: {
             play: function (childView, shape) {
-                shape.scaleX = 0.5;
-                shape.scaleY = 0.5;
+                var newWidth = this.stage.canvas.width / 3,
+                    width = 200,
+                    scale;
 
-                var wrapperSize = this.stage.canvas.width / 3,
-                    padding = 0;
+                scale = (1.0 * newWidth) / width;
 
-                if (wrapperSize > 100) {
-                    padding = (wrapperSize - 100) / 2;
-                }
+                shape.scaleX = scale;
+                shape.scaleY = scale;
 
-                shape.x = childView.model.get('x') + padding;
-                shape.y = childView.model.get('y') + padding;
+                shape.x = childView.model.get('x');
+                shape.y = childView.model.get('y');
                 this.stage.addChild(shape);
             }
         },


### PR DESCRIPTION
Calculating shape scale to better fill the spaces.
The sprite frame size is `200x200`, which is scale `1.0`.
The formula is:

```
200 => 1.0
newScale = (1.0 * newWidth) / 200
```

Some screenshots to show the difference:
## Before:

![screenshot 2015-10-14 13 47 37](https://cloud.githubusercontent.com/assets/3727827/10491003/81846160-727a-11e5-88c6-b3c7e20fe32e.png)
![screen shot 2015-10-14 at 13 47 28](https://cloud.githubusercontent.com/assets/3727827/10491013/8ec94b42-727a-11e5-9fda-66f6946bb77d.png)
## After:

![screenshot 2015-10-14 13 46 40](https://cloud.githubusercontent.com/assets/3727827/10491004/818b0e2a-727a-11e5-8dbc-9cc7e9f1b341.png)
![screen shot 2015-10-14 at 13 46 27](https://cloud.githubusercontent.com/assets/3727827/10491014/8eca2f30-727a-11e5-86c2-a5ee1361946a.png)

ref #1
